### PR TITLE
Support CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ RIE_ENDPOINT=http://custom-host:9000/2015-03-31/functions/function/invocations a
 
 ## Environment Variables
 
-| Variable       | Description                                                                                                                                                                                                 | Default Value                                                     |
-| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| `RIE_ENDPOINT` | URL for the Lambda Runtime Interface Emulator (RIE)                                                                                                                                                         | `http://localhost:9000/2015-03-31/functions/function/invocations` |
-| `ENABLE_CORS`  | Set this to `"true"` to enable CORS for all origins, methods, and headers.<br>**Warning:** Enabling this setting may have security implications, Ensure you understand the implications before enabling it. | `"false"`                                                         |
+| Variable       | Description                                                                                                                                                  | Default Value                                                     |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------- |
+| `RIE_ENDPOINT` | URL for the Lambda Runtime Interface Emulator (RIE)                                                                                                          | `http://localhost:9000/2015-03-31/functions/function/invocations` |
+| `ENABLE_CORS`  | Set this to `"true"` to enable CORS for all origins, methods, and headers.<br>**Warning:** Please be aware that this options may have security implications. | `"false"`                                                         |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A lightweight Docker image to emulate **AWS Lambda Function URLs** locally. It w
 - Automatically forwards HTTP requests to a locally running Lambda function to work with the AWS Lambda Runtime Interface Emulator.
 - Supports `APIGatewayProxyEventV2` for HTTP API requests.
 - Handles `isBase64Encoded` for binary data.
+- Supports enabling CORS via an environment variable, allowing cross-origin requests.
 
 ## Getting Started
 
@@ -49,9 +50,10 @@ RIE_ENDPOINT=http://custom-host:9000/2015-03-31/functions/function/invocations a
 
 ## Environment Variables
 
-| Variable       | Description                                         | Default Value                                                     |
-| -------------- | --------------------------------------------------- | ----------------------------------------------------------------- |
-| `RIE_ENDPOINT` | URL for the Lambda Runtime Interface Emulator (RIE) | `http://localhost:9000/2015-03-31/functions/function/invocations` |
+| Variable       | Description                                                                                                                                                                                                 | Default Value                                                     |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `RIE_ENDPOINT` | URL for the Lambda Runtime Interface Emulator (RIE)                                                                                                                                                         | `http://localhost:9000/2015-03-31/functions/function/invocations` |
+| `ENABLE_CORS`  | Set this to `"true"` to enable CORS for all origins, methods, and headers.<br>**Warning:** Enabling this setting may have security implications, Ensure you understand the implications before enabling it. | `"false"`                                                         |
 
 ## License
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/daido1976/aws-lambda-function-url-emulator
 
 go 1.23.3
 
-require github.com/aws/aws-lambda-go v1.47.0 // indirect
+require (
+	github.com/aws/aws-lambda-go v1.47.0 // indirect
+	github.com/rs/cors v1.11.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/aws/aws-lambda-go v1.47.0 h1:0H8s0vumYx/YKs4sE7YM0ktwL2eWse+kfopsRI1sXVI=
 github.com/aws/aws-lambda-go v1.47.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
+github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
+github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=

--- a/main.go
+++ b/main.go
@@ -19,9 +19,6 @@ var port = getEnv("PORT", "8080")
 var rieEndpoint = getEnv("RIE_ENDPOINT", "http://localhost:9000/2015-03-31/functions/function/invocations")
 var enableCors = getEnv("ENABLE_CORS", "false")
 
-// It is a global variable for testing.
-var rootHandler http.Handler
-
 func getEnv(key, fallback string) string {
 	if value, exists := os.LookupEnv(key); exists {
 		return value
@@ -30,12 +27,15 @@ func getEnv(key, fallback string) string {
 }
 
 func main() {
+	var rootHandler http.Handler
+
 	if enableCors == "true" {
 		rootHandler = cors.AllowAll().Handler(http.HandlerFunc(lambdaUrlProxyHandler))
 		log.Println("[Lambda URL Proxy] CORS enabled")
 	} else {
 		rootHandler = http.HandlerFunc(lambdaUrlProxyHandler)
 	}
+
 	http.Handle("/", rootHandler)
 	log.Printf("[Lambda URL Proxy] Listening on http://localhost:%s\n", port)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", port), nil))

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func getEnv(key, fallback string) string {
 
 func main() {
 	if enableCors == "true" {
-		rootHandler = cors.Default().Handler(http.HandlerFunc(lambdaUrlProxyHandler))
+		rootHandler = cors.AllowAll().Handler(http.HandlerFunc(lambdaUrlProxyHandler))
 		log.Println("[Lambda URL Proxy] CORS enabled")
 	} else {
 		rootHandler = http.HandlerFunc(lambdaUrlProxyHandler)

--- a/main.go
+++ b/main.go
@@ -12,10 +12,15 @@ import (
 	"time"
 
 	"github.com/aws/aws-lambda-go/events"
+	"github.com/rs/cors"
 )
 
 var port = getEnv("PORT", "8080")
 var rieEndpoint = getEnv("RIE_ENDPOINT", "http://localhost:9000/2015-03-31/functions/function/invocations")
+var enableCors = getEnv("ENABLE_CORS", "false")
+
+// It is a global variable for testing.
+var rootHandler http.Handler
 
 func getEnv(key, fallback string) string {
 	if value, exists := os.LookupEnv(key); exists {
@@ -25,12 +30,18 @@ func getEnv(key, fallback string) string {
 }
 
 func main() {
-	http.HandleFunc("/", handler)
+	if enableCors == "true" {
+		rootHandler = cors.Default().Handler(http.HandlerFunc(lambdaUrlProxyHandler))
+		log.Println("[Lambda URL Proxy] CORS enabled")
+	} else {
+		rootHandler = http.HandlerFunc(lambdaUrlProxyHandler)
+	}
+	http.Handle("/", rootHandler)
 	log.Printf("[Lambda URL Proxy] Listening on http://localhost:%s\n", port)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", port), nil))
 }
 
-func handler(w http.ResponseWriter, r *http.Request) {
+func lambdaUrlProxyHandler(w http.ResponseWriter, r *http.Request) {
 	// Log the incoming request
 	log.Printf("[Lambda URL Proxy] %s %s\n", r.Method, r.URL.String())
 

--- a/main_test.go
+++ b/main_test.go
@@ -37,7 +37,7 @@ func TestHandler(t *testing.T) {
 
 	rieEndpoint = mockRieServer.URL
 
-	server := httptest.NewServer(http.HandlerFunc(handler))
+	server := httptest.NewServer(http.HandlerFunc(lambdaUrlProxyHandler))
 	defer server.Close()
 
 	req, _ := http.NewRequest("POST", server.URL+"/foo/bar?testkey=testvalue", strings.NewReader("test body"))

--- a/test/compose.yaml
+++ b/test/compose.yaml
@@ -7,6 +7,8 @@ services:
       - "8080:8080"
     environment:
       RIE_ENDPOINT: "http://test-lambda-rie:8080/2015-03-31/functions/function/invocations"
+      # Uncomment out when testing for CORS.
+      # ENABLE_CORS: "true"
   test-lambda-rie:
     build:
       context: ./lambda


### PR DESCRIPTION
## Overview

Issue: https://github.com/daido1976/aws-lambda-function-url-emulator/issues/1

Inspired by LocalStack, I considered supporting environment variables like `CORS_ALLOWED_ORIGINS`, `CORS_ALLOWED_HEADERS`, and `CORS_ALLOWED_METHODS`. However, since this is a tool for local development, I wasn’t sure if such detailed configurations were necessary. For now, I decided to support only the `ENABLE_CORS` environment variable.

The implementation is minimal, setting `Access-Control-Allow-Origin: *`. This does not allow credentials like cookies to be sent across origins. However, the current implementation does not support cookies at all, so this should not be an issue.

If additional issues are raised, I will consider supporting more detailed configurations.

## Note

- https://docs.aws.amazon.com/ja_jp/lambda/latest/dg/urls-configuration.html#urls-cors
- https://docs.localstack.cloud/references/configuration/#security
- https://github.com/localstack/localstack/blob/v4.0.3/localstack-core/localstack/aws/handlers/cors.py
- https://github.com/rs/cors  

## Operation Check

Check the operation with `ENABLE_CORS: true` in the test directory.

- <img src='https://github.com/user-attachments/assets/55b1ff03-63f5-464d-9677-773ac76bee99' width=480>
- <img src='https://github.com/user-attachments/assets/56d753b5-f7df-4c1e-b2f5-4f79ddb46c43' width=480>